### PR TITLE
Build appendHeaderLink action function

### DIFF
--- a/src/SlackMessage.js
+++ b/src/SlackMessage.js
@@ -12,6 +12,10 @@ class SlackMessageRoot {
     return;
   }
 
+  async appendHeaderLink() {
+    return;
+  }
+
   async initialize() {
     return;
   }

--- a/src/SlackMessage.mock.js
+++ b/src/SlackMessage.mock.js
@@ -12,6 +12,7 @@ class SlackMessage extends SlackMessageRoot {
     this.#_spies = {
       initialize: sinon.spy(),
       appendBlock: sinon.spy(),
+      appendHeaderLink: sinon.spy(),
     };
   }
 
@@ -23,6 +24,11 @@ class SlackMessage extends SlackMessageRoot {
 
   get ts() {
     return this.#_ts;
+  }
+
+  async appendHeaderLink(link) {
+    this.#_spies.appendHeaderLink(link);
+    return;
   }
 
   async sendBlock(block) {

--- a/src/appendHeaderLink.js
+++ b/src/appendHeaderLink.js
@@ -1,0 +1,51 @@
+const { SlackMessageRoot } = require("./SlackMessage");
+
+module.exports =
+  (slackMessage) =>
+  async (
+    sender = { name: "string", avatar: "" },
+    workflowLink = "",
+    header = "Build"
+  ) => {
+    if (!slackMessage) throw new Error("Slack Message object must be provided");
+    if (!(slackMessage instanceof SlackMessageRoot))
+      throw new Error("slackMessage must be SlackMessage object");
+
+    // await slackMessage.initialize(
+    //   constructMessage(sender, workflowLink, header)
+    // );
+    // return slackMessage.ts;
+  };
+
+// function constructMessage(sender, workflowLink, header) {
+//   return {
+//     text: `:construction: ${header} :construction: `,
+//     blocks: [
+//       {
+//         type: "header",
+//         text: {
+//           type: "plain_text",
+//           text: `:construction: ${header} :construction: `,
+//           emoji: true,
+//         },
+//       },
+//       {
+//         type: "context",
+//         elements: [
+//           {
+//             type: "image",
+//             image_url: sender.avatar,
+//             alt_text: sender.name,
+//           },
+//           {
+//             type: "mrkdwn",
+//             text: `*${sender.name}* has triggered an action.\n<${workflowLink}|Watch Progress>`,
+//           },
+//         ],
+//       },
+//       {
+//         type: "divider",
+//       },
+//     ],
+//   };
+// }

--- a/src/appendHeaderLink.js
+++ b/src/appendHeaderLink.js
@@ -1,51 +1,11 @@
 const { SlackMessageRoot } = require("./SlackMessage");
 
-module.exports =
-  (slackMessage) =>
-  async (
-    sender = { name: "string", avatar: "" },
-    workflowLink = "",
-    header = "Build"
-  ) => {
-    if (!slackMessage) throw new Error("Slack Message object must be provided");
-    if (!(slackMessage instanceof SlackMessageRoot))
-      throw new Error("slackMessage must be SlackMessage object");
+module.exports = (slackMessage) => async (link) => {
+  if (!slackMessage) throw new Error("Slack Message object must be provided");
+  if (!(slackMessage instanceof SlackMessageRoot))
+    throw new Error("slackMessage must be SlackMessage object");
+  if (!link) throw new Error("link must be provided");
 
-    // await slackMessage.initialize(
-    //   constructMessage(sender, workflowLink, header)
-    // );
-    // return slackMessage.ts;
-  };
-
-// function constructMessage(sender, workflowLink, header) {
-//   return {
-//     text: `:construction: ${header} :construction: `,
-//     blocks: [
-//       {
-//         type: "header",
-//         text: {
-//           type: "plain_text",
-//           text: `:construction: ${header} :construction: `,
-//           emoji: true,
-//         },
-//       },
-//       {
-//         type: "context",
-//         elements: [
-//           {
-//             type: "image",
-//             image_url: sender.avatar,
-//             alt_text: sender.name,
-//           },
-//           {
-//             type: "mrkdwn",
-//             text: `*${sender.name}* has triggered an action.\n<${workflowLink}|Watch Progress>`,
-//           },
-//         ],
-//       },
-//       {
-//         type: "divider",
-//       },
-//     ],
-//   };
-// }
+  await slackMessage.appendHeaderLink(link);
+  return slackMessage.ts;
+};

--- a/test/appendHeaderLink.spec.js
+++ b/test/appendHeaderLink.spec.js
@@ -1,0 +1,54 @@
+const { use, expect } = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+use(chaiAsPromised);
+
+const SlackMessage = require("../src/SlackMessage.mock");
+const appendHeaderLink = require("../src/appendHeaderLink");
+
+describe("appendHeaderLink", () => {
+  it("Throws when you don't provide a SlackMessage", async () => {
+    const result = appendHeaderLink()();
+    return expect(result).to.be.rejected;
+  });
+
+  // it("Throws when slack message isn't a SlackMessage instance", async () => {
+  //   const result = initializeMessage({})(
+  //     {
+  //       name: "spruce-bruce",
+  //       avatar: "https://avatars.githubusercontent.com/u/59978?v=4",
+  //     },
+  //     "http://example.com",
+  //     "Build"
+  //   );
+
+  //   return expect(result).to.be.rejected;
+  // });
+
+  // it("Successfully returns a slack message timestamp", async () => {
+  //   const slackMessage = new SlackMessage("1234.1234");
+  //   const result = await initializeMessage(slackMessage)(
+  //     {
+  //       name: "spruce-bruce",
+  //       avatar: "https://avatars.githubusercontent.com/u/59978?v=4",
+  //     },
+  //     "http://example.com",
+  //     "Build"
+  //   );
+
+  //   expect(result).to.eq("1234.1234");
+  // });
+
+  // it("Optionally takes a header for the message", async () => {
+  //   const slackMessage = new SlackMessage("1234.1234");
+  //   const result = await initializeMessage(slackMessage)(
+  //     {
+  //       name: "spruce-bruce",
+  //       avatar: "https://avatars.githubusercontent.com/u/59978?v=4",
+  //     },
+  //     "http://example.com",
+  //     "Build"
+  //   );
+
+  //   expect(result).to.eq("1234.1234");
+  // });
+});

--- a/test/appendHeaderLink.spec.js
+++ b/test/appendHeaderLink.spec.js
@@ -7,48 +7,27 @@ const appendHeaderLink = require("../src/appendHeaderLink");
 
 describe("appendHeaderLink", () => {
   it("Throws when you don't provide a SlackMessage", async () => {
-    const result = appendHeaderLink()();
+    const result = appendHeaderLink()("link");
     return expect(result).to.be.rejected;
   });
 
-  // it("Throws when slack message isn't a SlackMessage instance", async () => {
-  //   const result = initializeMessage({})(
-  //     {
-  //       name: "spruce-bruce",
-  //       avatar: "https://avatars.githubusercontent.com/u/59978?v=4",
-  //     },
-  //     "http://example.com",
-  //     "Build"
-  //   );
+  it("Throws when slack message isn't a SlackMessage instance", async () => {
+    const result = appendHeaderLink({})("link");
+    return expect(result).to.be.rejected;
+  });
 
-  //   return expect(result).to.be.rejected;
-  // });
+  it("Sends link to slack and returns timestamp", async () => {
+    const slackMessage = new SlackMessage("1234.1234");
+    await appendHeaderLink(slackMessage)("https://www.google.com");
 
-  // it("Successfully returns a slack message timestamp", async () => {
-  //   const slackMessage = new SlackMessage("1234.1234");
-  //   const result = await initializeMessage(slackMessage)(
-  //     {
-  //       name: "spruce-bruce",
-  //       avatar: "https://avatars.githubusercontent.com/u/59978?v=4",
-  //     },
-  //     "http://example.com",
-  //     "Build"
-  //   );
+    const appendHeaderSpy = slackMessage.getSpy("appendHeaderLink");
+    expect(appendHeaderSpy.calledOnce).to.be.true;
+    expect(appendHeaderSpy.args[0][0]).to.equal("https://www.google.com");
+  });
 
-  //   expect(result).to.eq("1234.1234");
-  // });
-
-  // it("Optionally takes a header for the message", async () => {
-  //   const slackMessage = new SlackMessage("1234.1234");
-  //   const result = await initializeMessage(slackMessage)(
-  //     {
-  //       name: "spruce-bruce",
-  //       avatar: "https://avatars.githubusercontent.com/u/59978?v=4",
-  //     },
-  //     "http://example.com",
-  //     "Build"
-  //   );
-
-  //   expect(result).to.eq("1234.1234");
-  // });
+  it("fails when link is not provided", () => {
+    const slackMessage = new SlackMessage("1234.1234");
+    const result = appendHeaderLink(slackMessage)();
+    return expect(result).to.be.rejected;
+  });
 });


### PR DESCRIPTION
This action still won't work because the non-mocked SlackMessage class
doesn't have an appendHeaderLink function, but this action isn't
callable by anything in prod so there are no breaking changes.

My next PR will introduce and test the changes to SlackMessage