### PR TITLE
add header link

### DIFF
--- a/test/SlackMessage.spec.js
+++ b/test/SlackMessage.spec.js
@@ -192,4 +192,119 @@ describe("SlackMessage", () => {
       "The notification bot must be a member of this channel for build updates to work"
     );
   });
+
+  describe("appendHeaderLink", () => {
+    it("fails to append a header link when no link is supplied", async () => {
+      const message = new SlackMessage("TOKEN", {
+        channel: "C12345",
+        ts: "1234.1234",
+      });
+
+      const result = message.appendHeaderLink();
+      return expect(result).to.be.rejectedWith(Error, "link must be defined");
+    });
+
+    it("fails to append header link when link type is wrong", async () => {
+      const message = new SlackMessage("TOKEN", {
+        channel: "C12345",
+        ts: "1234.1234",
+      });
+
+      const result = message.appendHeaderLink(20);
+      return expect(result).to.be.rejectedWith(
+        Error,
+        "link must be a string or an object"
+      );
+    });
+
+    it("fails to append header link when object is malformed", () => {
+      const message = new SlackMessage("TOKEN", {
+        channel: "C12345",
+        ts: "1234.1234",
+      });
+
+      const result = message.appendHeaderLink({ invalid: "key" });
+      return expect(result).to.be.rejectedWith(
+        Error,
+        "Object must contain 'url' and 'text' keys"
+      );
+    });
+
+    it("Successfully sends a simple url", async () => {
+      const message = new SlackMessage("TOKEN", {
+        channel: "C12345",
+        ts: "1234.1234",
+      });
+
+      server.use(
+        rest.get(
+          "https://slack.com/api/conversations.history",
+          (_req, res, ctx) => {
+            return res(ctx.json(mockHistoryResponse()));
+          }
+        )
+      );
+
+      server.use(
+        rest.post("https://slack.com/api/chat.update", (_req, res, ctx) => {
+          return res(ctx.json(mockMessageResponse()));
+        })
+      );
+
+      const postEvents = waitForRequest(
+        server,
+        "POST",
+        "https://slack.com/api/chat.update"
+      );
+
+      await message.appendHeaderLink("https://google.com");
+
+      const response = await postEvents;
+      expect(response.body.ts).to.equal("1234.1234");
+      expect(response.body.channel).to.equal("C12345");
+      expect(response.body.blocks[1].elements[1].text).to.have.string(
+        "<https://google.com>|https://google.com>"
+      );
+    });
+
+    it("Successfully sends a simple url", async () => {
+      const message = new SlackMessage("TOKEN", {
+        channel: "C12345",
+        ts: "1234.1234",
+      });
+
+      server.use(
+        rest.get(
+          "https://slack.com/api/conversations.history",
+          (_req, res, ctx) => {
+            return res(ctx.json(mockHistoryResponse()));
+          }
+        )
+      );
+
+      server.use(
+        rest.post("https://slack.com/api/chat.update", (_req, res, ctx) => {
+          return res(ctx.json(mockMessageResponse()));
+        })
+      );
+
+      const postEvents = waitForRequest(
+        server,
+        "POST",
+        "https://slack.com/api/chat.update"
+      );
+
+      await message.appendHeaderLink({
+        url: "https://google.com",
+        text: "WOW COOL",
+      });
+
+      const response = await postEvents;
+      expect(response.body.ts).to.equal("1234.1234");
+      expect(response.body.channel).to.equal("C12345");
+      expect(response.body.blocks[1].elements[1].text).to.have.string(
+        "<https://google.com>|WOW COOL>"
+      );
+    });
+  });
 });

--- a/test/mockHistoryResponse.js
+++ b/test/mockHistoryResponse.js
@@ -30,9 +30,28 @@ module.exports = () => ({
           block_id: "uu34",
           text: {
             type: "plain_text",
-            text: "Build Update",
+            text: ":construction: Some Cool Build :construction: ",
             emoji: true,
           },
+        },
+        {
+          type: "context",
+          block_id: "b0i",
+          elements: [
+            {
+              type: "image",
+              image_url: "https://avatars.githubusercontent.com/u/59978?v=4",
+              alt_text: "spruce-bruce",
+            },
+            {
+              type: "mrkdwn",
+              text: "*spruce-bruce* has triggered an action.\n<https://google.com|Watch Progress>",
+            },
+          ],
+        },
+        {
+          type: "divider",
+          block_id: "d00d",
         },
         {
           type: "section",


### PR DESCRIPTION
#11 
This PR adds the `appendHeaderLink` function to the `SlackMessage` class. This function does all the work of interacting with Slack's api in order to build the correct message and pass it back to slack.

It's a little bit ugly so I'm going to refactor a little bit, but this is a good time to merge so the PR doesn't get out of hand.