### PR TITLE
adds the push command to the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           git config --global user.email "<>"
           git config --global user.name "Github Actions Build"
           git diff-index --quiet HEAD || git commit -am "Build ${{ github.run_number }}"
+          git push
 
   Test_Init:
     name: Initialize Test Notification


### PR DESCRIPTION
#11

Looks like I left out the `git push` command from when I automated the build :oof:
